### PR TITLE
Refresh window fix

### DIFF
--- a/scripts/rockSaw.lua
+++ b/scripts/rockSaw.lua
@@ -27,12 +27,9 @@ end
 function start()
 	for i=1, passCount do
 		-- refresh windows
-        message = "Refreshing"
-		clickAllText("This is");
+		clickAllText("This Rock Saw");
 		lsSleep(500);
 		
-		message = "Clicking " .. product;
-
         if cutstone then
 			clickAllText("Make a Cut Stone");
         elseif medstone then


### PR DESCRIPTION
Rocksaw wording changes to 'This Rock Saw' rather than 'This is' - updated the clickAllText accordingly to correctly refresh the window at the end of each pass.