### PR TITLE
Pottery Wheel - More accurate timer on moulding jugs

### DIFF
--- a/scripts/potteryAuto.lua
+++ b/scripts/potteryAuto.lua
@@ -121,7 +121,7 @@ function config()
 	end
 	
 	msTimer = (timer * 60) * 1000
-    msTimerTeppyDuckOffset = (duckTeppyOffset * timer) * 1300 -- Add extra time to compensate for duck/teppy time
+    msTimerTeppyDuckOffset = (duckTeppyOffset * timer) * 1600 -- Add extra time to compensate for duck/teppy time
 	adjustedTimer = msTimer + msTimerTeppyDuckOffset;
 
     if jug or mortar then


### PR DESCRIPTION
The timer was off on moulding jugs on a pottery wheel in live so it would skip every 2nd pass.