### PR TITLE
Better method for finding 'Eat some' text

### DIFF
--- a/scripts/statclicks.lua
+++ b/scripts/statclicks.lua
@@ -190,7 +190,7 @@ end
 
 function digHole()
     digText = findText("Dig Deeper");
-    grilledOnion = waitForText("Grilled Onions");
+    grilledOnion = findText("Grilled Onions");
         
     if digText ~= nil then            
         if grilledOnion then
@@ -218,7 +218,7 @@ function combFlax()
     if (fix) then
         repairRake();
     end
-    grilledOnion = waitForText("Grilled Onions");
+    grilledOnion = findText("Grilled Onions");
     if grilledOnion then
         eatOnion();
     end
@@ -262,7 +262,7 @@ function hacklingRake()
     if (fix) then
         repairRake();
     end
-    grilledOnion = waitForText("Grilled Onions");
+    grilledOnion = findText("Grilled Onions");
     if grilledOnion then
         eatOnion();
     end


### PR DESCRIPTION
Switched to FindText for auto eating onions while using statclicks.lua to stop the script freezing if the text is not visible at any point.