### PR TITLE
Incorrect metal requirement

### DIFF
--- a/scripts/forgeItems.txt
+++ b/scripts/forgeItems.txt
@@ -3,7 +3,7 @@ return
 	["Extrusion Plate"] = 
 	{
 		["masterOnly"] = true,
-		["metal"] = "Iron",
+		["metal"] = "Copper",
 		["prod"] = 1,
 		["q"] = 40,
 		["time"] = 30,


### PR DESCRIPTION
Extrusion plates where showing in automato as requiring 40 Iron when they require Copper.