### PR TITLE
Timer tweak

### DIFF
--- a/scripts/saltWater.lua
+++ b/scripts/saltWater.lua
@@ -206,7 +206,7 @@ function promptDelays()
     end
 
 	msTimer = (timer * 60) * 1000
-    msTimerTeppyDuckOffset = (duckTeppyOffset * timer) * 1300 -- Add extra time to compensate for duck/teppy time
+    msTimerTeppyDuckOffset = (duckTeppyOffset * timer) * 1000 -- Add extra time to compensate for duck/teppy time
 	adjustedTimer = msTimer + msTimerTeppyDuckOffset;
 
 


### PR DESCRIPTION
Reduced the timer on refilling a tub with saltwater by 1 minute as per the changelog in game whereby its better to refill before it emptys than wait for 1 full "use"