### PR TITLE
Slight window spacing increase

### DIFF
--- a/scripts/cc_Assist.lua
+++ b/scripts/cc_Assist.lua
@@ -65,7 +65,7 @@ buttons = {
 function doit()
   askForWindow(askText);
 	--function windowManager(title, message, allowCascade, allowWaterGap, varWidth, varHeight, sizeRight, offsetWidth, offsetHeight)
-  windowManager("Charcoal Setup", wmText, nil, nil, nil, nil, nil, nil, 16);  --add 16 extra pixels to window height because window expands with 'Take...' menu after first batch is created
+  windowManager("Charcoal Setup", wmText, nil, nil, nil, nil, nil, 15, 22);  --add 16 extra pixels to window height because window expands with 'Take...' menu after first batch is created
   unpinOnExit(ccMenu);
 end
 


### PR DESCRIPTION
Very small window spacing increase when using the window managers "Form Grid" option to avoid the cc hearth windows overlapping.