### PR TITLE
Correctly set walkTo options

### DIFF
--- a/scripts/.luacheckrc
+++ b/scripts/.luacheckrc
@@ -153,6 +153,8 @@ stds.common = {
 }
 stds.automato = {
   read_globals = {
+	"MB_YES",
+	"MB_NO",
     "lsAltHeld",
     "lsAnalyzeCustom",
     "lsAnalyzePapyrus",


### PR DESCRIPTION
Correctly reset 'rot_flax' and 'water_needed' back to false if the readClock option is unchecked.