### PR TITLE
Improved window spacing

### DIFF
--- a/scripts/kettle_full.lua
+++ b/scripts/kettle_full.lua
@@ -216,7 +216,7 @@ end
 
 function doit()
   askForWindow(askText);
-  windowManager("Kettle Setup", wmText, false, true, 215, 288);
+  windowManager("Kettle Setup", wmText, false, true, 215, 288, nil, 10, 25);
   askForFocus();
   unpinOnExit(menuKettles);
 end


### PR DESCRIPTION
Slight increase on the window spacing for kettle windows, they should no longer overlap causing the macro to fail at taking the product and get stuck in an endless loop.