### PR TITLE
ToxinKitchen.lua: only allow white Constitution, not dark red, before starting.

### DIFF
--- a/scripts/ToxinKitchen.lua
+++ b/scripts/ToxinKitchen.lua
@@ -537,9 +537,8 @@ function waitForCon()
 		--Search for black con timer
 		srReadScreen();
 		local image1 = srFindImage ("Constitution-Black.png", tol);
-		local image2 = srFindImage ("Constitution-DarkRed.png", 2000);
 
-		if not (image1 or image2) then
+		if not image1 then
 			local x = 10;
 			local y = 6;
 


### PR DESCRIPTION
Dark red matching may not be working properly anymore with T9, causing it to try to start a toxin batch before con timer is ready (i.e. bright red).