### PR TITLE
Correct material count

### DIFF
--- a/scripts/barrelVise.lua
+++ b/scripts/barrelVise.lua
@@ -181,7 +181,7 @@ function doit()
 
 	-- testReorder();
 	num_barrels = promptNumber("How many barrels?", 1);
-	askForWindow("Have 100 Boards, 2 Copper Straps, and 80 Wood in your inventory for every barrel you want to make.\n	\nFor large numbers of barrels you can get away with less wood, the average used is 60.\n	\nPin as many vises as you want, put the cursor over the ATITD window, press Shift.");
+	askForWindow("Have " .. 100*num_barrels  .. " Boards, " .. 2*num_barrels .. " Copper Straps & " .. 80*num_barrels .. " Wood in your inventory for every barrel you want to make.\n	\nFor large numbers of barrels you can get away with less wood, the average used is 60.\n	\nPin as many vises as you want, put the cursor over the ATITD window, press Shift.");
 
 	srReadScreen();
 


### PR DESCRIPTION
barrelVise now shows the correct volume of materials required depending on how many barrels are being processed, rather than just the base materials per barrel.