### PR TITLE
Reduced scanning radius

### DIFF
--- a/scripts/paint_mix.lua
+++ b/scripts/paint_mix.lua
@@ -68,27 +68,38 @@ end
 
 function makePaintBatch(config, num_batches, size)
     srReadScreen();
-    local paint_buttons = findAllImages("plus.png");
-    if (#paint_buttons == 0) then
-        error "No buttons found";
-    end
+    local pigmentLab = findAllText("Pigment Laboratory");
+    
+    for i=1,#pigmentLab do
+        
+        local x = pigmentLab[i][0];
+        local y = pigmentLab[i][1];
+        local width = 320;
+        local height = 540;
 
-    for i=1, num_batches do
-        checkBreak();
-        for iidx=1, #recipes[config.color_index].ingredient do
-            for aidx=1, recipes[config.color_index].amount[iidx] do
-                checkBreak();
-                local buttonNo = BUTTON_INDEX[recipes[config.color_index].ingredient[iidx]];
-                srClickMouseNoMove(paint_buttons[buttonNo][0]+2,paint_buttons[buttonNo][1]+2, right_click);
-                sleepWithStatus(click_delay, "Making paint batch " .. i .. " of " .. math.floor(num_batches));
+        srReadScreen();  
+        local paint_buttons = findAllImagesInRange("plus.png", x, y, width, height);
+        if (#paint_buttons == 0) then
+            error "No buttons found";
+        end
+
+        for i=1, num_batches do
+            checkBreak();
+            for iidx=1, #recipes[config.color_index].ingredient do
+                for aidx=1, recipes[config.color_index].amount[iidx] do
+                    checkBreak();
+                    local buttonNo = BUTTON_INDEX[recipes[config.color_index].ingredient[iidx]];
+                    srClickMouseNoMove(paint_buttons[buttonNo][0]+2,paint_buttons[buttonNo][1]+2, right_click);
+                    sleepWithStatus(click_delay, "Making paint batch " .. i .. " of " .. math.floor(num_batches));
+                end
             end
+            srReadScreen();
+            lsSleep(100);
+            if take_paint then
+                clickAllText("Take the Paint");
+            end
+            lsSleep(100);
         end
-        srReadScreen();
-        lsSleep(100);
-        if take_paint then
-            clickAllText("Take the Paint");
-        end
-        lsSleep(100);
     end
 end
 


### PR DESCRIPTION
This was reading the whole screen, which meant that it detected the + icon on the map window and if there was any + symbols in the chat box which then causes the paint macro to miss click and not produce paint correctly.

I've added a boundry for it to search within for the + icon, so that should no longer happen.