### PR TITLE
Scan Boundary, Additional Reset Clicks

### DIFF
--- a/scripts/paint_common.inc
+++ b/scripts/paint_common.inc
@@ -124,6 +124,8 @@ end
 
 -- the map causes problems with paint scripts because the zoom buttons are the same as the paint add buttons
 -- this causes off-by-one errors if the map is open when making paint, so we close it before any paint scripts start
+
+-- May 31st 2020: Fixed this issue by adding a boundary for where to scan, this function is now redundant - Rhaom
 function close_map()
     srReadScreen();
     map_close = findAllImages("map_close.png");

--- a/scripts/paint_mix.lua
+++ b/scripts/paint_mix.lua
@@ -136,30 +136,8 @@ function makePaint(config, paint_amount)
     end
 end
 
-function close_map()
-    srReadScreen();
-    map_close = findAllImages("map_close.png");
-
-    if map_close then
-        for i=1, #map_close do
-            -- click near each 'x' in turn to see if that brings the map into focus
-            srClickMouse(map_close[i][0]-10,map_close[i][1]);
-            lsSleep(200);
-            srReadScreen();
-            map_text = findText("Map of Egypt");
-            if map_text then
-                print("Map found, closing");
-                srClickMouse(map_close[i][0]+5,map_close[i][1]+5);
-                break;
-            end
-        end
-    end
-end
-
 function mixPaint(config)
-    close_map();
     srReadScreen();
-
     batch_picker = findText("Batch Size...");
     if batch_picker then
         makePaint(config, config.paint_amount);

--- a/scripts/paint_watch.lua
+++ b/scripts/paint_watch.lua
@@ -43,13 +43,9 @@ function doit()
     local y = 0;
     local button_push = 0;
 
-    lsSetCaptureWindow();
-
     askForWindow("Pin your Pigment Laboratory window, anywhere (but don\'t move it once you start macro).\n\nNote: You will want to keep a supply of Red Sand for the Reset button (100 to test all reactions should be fine).\n\nClicking the 'Reset' button will set your Pigment Lab 'back to Black' color, again, but it requires Red Sand to do so. It\'s Magic!\n\nIf you have an Upgraded Pigment Laboratory, be sure to set Batch = 1x so you use LEAST amount of resources while testing reactions!");
 
-    close_map();
     srReadScreen();
-    xyWindowSize = srGetWindowSize();
     findBigColorBar();
 
     local paint_buttons = findAllImages("plus.png");
@@ -57,14 +53,14 @@ function doit()
         error "No buttons found";
     end
 
-
     while 1 do
         lsSetCamera(0,0,lsScreenX*1.5,lsScreenY*1.5);
         -- Where to start putting buttons/text on the screen.
         y = 10;
         
         if lsButtonText(lsScreenX - 10, 50, 0, 100, 0xff6251ff, "Reset") then
-            reset(paint_count);
+            sleepWithStatus(6000,"What is paint_count >> " .. paint_count)
+            reset(paint_count);  
             paint_sum = {0,0,0};
             paint_count = 0;
             bar_colour = {0,0,0};
@@ -75,7 +71,7 @@ function doit()
             px_G = nil;
             px_B = nil;
             px_A = nil;
-            update_now = 1;
+            update_now = 0;
             added = {}; -- Erase the array
         end
 
@@ -108,17 +104,7 @@ function doit()
             --{
                 -- click the appropriate button to add paint.
                 paint_value, paint_count = click_ingredient(button_names[button_push]);
-            
-                if(button_push < catalyst1) then
-                    -- add the paint estimate 
-                    paint_sum[1] =     paint_sum[1] + paint_value[1];
-                    paint_sum[2] =     paint_sum[2] + paint_value[2];
-                    paint_sum[3] =     paint_sum[3] + paint_value[3];
-                    paint_count = paint_count + 1.0;
-                end
-
                 table.insert(added, button_names[button_push]);
-
             --}
             end
 

--- a/scripts/paint_watch.lua
+++ b/scripts/paint_watch.lua
@@ -59,7 +59,6 @@ function doit()
         y = 10;
         
         if lsButtonText(lsScreenX - 10, 50, 0, 100, 0xff6251ff, "Reset") then
-            sleepWithStatus(6000,"What is paint_count >> " .. paint_count)
             reset(paint_count);  
             paint_sum = {0,0,0};
             paint_count = 0;


### PR DESCRIPTION
close_map() is now a redundant function as I have added a scan boundary on the pigment lab so I have removed it from paint_mix and paint_watch.

paint_watch was not counting clicks correctly, which meant it was always using -1 the amount of Red Sand required to reset the lab correctly.